### PR TITLE
Clarified version of solo key reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,12 @@
           <span v-if="webauthn_support" v-text="webauthn_support"></span>
           <br>
 
-          Solo firmware version:
+          Your Solo Key's firmware version:
           <span v-if="solo_version" v-text="solo_version"></span>
           <span v-else>unknown</span>
           <br>
 
-          Latest Solo firmware version:
+          Latest Solo Key firmware available version:
           <span v-if="stable_version" v-text="stable_version"></span>
           <span v-else>unknown</span>
         </p>

--- a/index.html
+++ b/index.html
@@ -23,12 +23,12 @@
           <span v-if="webauthn_support" v-text="webauthn_support"></span>
           <br>
 
-          Your Solo Key's firmware version:
+          Your Solo key's firmware version:
           <span v-if="solo_version" v-text="solo_version"></span>
           <span v-else>unknown</span>
           <br>
 
-          Latest Solo Key firmware available version:
+          Latest Solo key firmware available version:
           <span v-if="stable_version" v-text="stable_version"></span>
           <span v-else>unknown</span>
         </p>


### PR DESCRIPTION
Updated language so it's clearer that it's the user's solo key being referred to when the version is being reported.